### PR TITLE
WatchOSからタイムスタンプを押せるように更新

### DIFF
--- a/TimeStamp Watch App/AddTimeStampView.swift
+++ b/TimeStamp Watch App/AddTimeStampView.swift
@@ -17,5 +17,5 @@ struct AddTimeStampView: View {
 }
 
 #Preview {
-    AddTimeStampView(viewModel: AddTimeStampViewModel(repository: UserDefaultTimeStampRepository(userDefault: .standard)))
+    AddTimeStampView(viewModel: AddTimeStampViewModel())
 }

--- a/TimeStamp Watch App/AddTimeStampViewModel.swift
+++ b/TimeStamp Watch App/AddTimeStampViewModel.swift
@@ -10,8 +10,12 @@ import WatchConnectivity
 
 final class AddTimeStampViewModel: NSObject, ObservableObject {
     
+    private let session = WCSession.default
+    
     override init() {
         super.init()
+        
+        setupSession()
     }
     
     enum Action {
@@ -25,7 +29,18 @@ final class AddTimeStampViewModel: NSObject, ObservableObject {
         }
     }
     
+    private func setupSession() {
+        if WCSession.isSupported() {
+            session.delegate = self
+            session.activate()
+        }
+    }
+    
     private func edit(timeStamp: TimeStamp) {
+        guard let jsonData = TimeStampCorder().encode(timeStamps: [timeStamp]) else { return }
+        session.sendMessageData(jsonData, replyHandler: nil) { error in
+            print(error.localizedDescription)
+        }
     }
 }
 

--- a/TimeStamp Watch App/AddTimeStampViewModel.swift
+++ b/TimeStamp Watch App/AddTimeStampViewModel.swift
@@ -8,10 +8,8 @@
 import Foundation
 
 final class AddTimeStampViewModel: ObservableObject {
-    private let repository: UserDefaultTimeStampRepository
     
-    init(repository: UserDefaultTimeStampRepository) {
-        self.repository = repository
+    init() {
     }
     
     enum Action {
@@ -26,6 +24,5 @@ final class AddTimeStampViewModel: ObservableObject {
     }
     
     private func edit(timeStamp: TimeStamp) {
-        repository.edit(timeStamp: timeStamp)
     }
 }

--- a/TimeStamp Watch App/AddTimeStampViewModel.swift
+++ b/TimeStamp Watch App/AddTimeStampViewModel.swift
@@ -6,10 +6,12 @@
 //
 
 import Foundation
+import WatchConnectivity
 
-final class AddTimeStampViewModel: ObservableObject {
+final class AddTimeStampViewModel: NSObject, ObservableObject {
     
-    init() {
+    override init() {
+        super.init()
     }
     
     enum Action {
@@ -24,5 +26,10 @@ final class AddTimeStampViewModel: ObservableObject {
     }
     
     private func edit(timeStamp: TimeStamp) {
+    }
+}
+
+extension AddTimeStampViewModel: WCSessionDelegate {
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
     }
 }

--- a/TimeStamp Watch App/ContentView.swift
+++ b/TimeStamp Watch App/ContentView.swift
@@ -8,17 +8,17 @@
 import SwiftUI
 
 struct ContentView: View {
+    @ObservedObject var viewModel: AddTimeStampViewModel
+    
+    init(viewModel: AddTimeStampViewModel) {
+        self.viewModel = viewModel
+    }
+    
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-        }
-        .padding()
+        AddTimeStampView(viewModel: viewModel)
     }
 }
 
 #Preview {
-    ContentView()
+    ContentView(viewModel: AddTimeStampViewModel())
 }

--- a/TimeStampApp/TimeStampApp.swift
+++ b/TimeStampApp/TimeStampApp.swift
@@ -12,13 +12,19 @@ struct TimeStampApp: App {
     private let repository = UserDefaultTimeStampRepository(userDefault: .standard)
     var body: some Scene {
         WindowGroup {
+            #if os(watchOS)
+            ContentView(viewModel: AddTimeStampViewModel())
+            #else
             ContentView(viewModel: TimeStampListViewModel(repository: repository))
+            #endif
         }
         
+        #if os(macOS)
         MenuBarExtra {
             AddTimeStampView(viewModel: AddTimeStampViewModel(repository: repository))
         } label: {
             Image(symbol: .timer)
         }
+        #endif
     }
 }

--- a/TimeStampApp/TimeStampListViewModel.swift
+++ b/TimeStampApp/TimeStampListViewModel.swift
@@ -83,13 +83,10 @@ extension TimeStampListViewModel {
                 return timeStamp.type ?? .none
             },
             set: { [weak self] newValue in
-                guard var timeStamps = self?.repository.timeStamps.value else { return }
-                if let index = timeStamps.firstIndex(where: { $0.id == timeStamp.id} ) {
-                    self?.timeStamps[index].type = newValue
-                    if let newTimeStamp = self?.timeStamps[index] {
-                        self?.repository.edit(timeStamp: newTimeStamp)
-                    }
-                }
+                guard var timeStamps = self?.timeStamps,
+                      let index = timeStamps.firstIndex(where: { $0.id == timeStamp.id} ) else { return }
+                timeStamps[index].type = newValue
+                self?.repository.edit(timeStamp: timeStamps[index])
             }
         )
     }

--- a/TimeStampApp/TimeStampListViewModel.swift
+++ b/TimeStampApp/TimeStampListViewModel.swift
@@ -103,8 +103,12 @@ extension TimeStampListViewModel: WCSessionDelegate {
     }
     
     func session(_ session: WCSession, didReceiveMessageData messageData: Data) {
-        if let timeStamps = TimeStampCorder().decode(data: messageData), let timeStamp = timeStamps.first {
-            self.edit(timeStamp: timeStamp)
+        guard let timeStamps = TimeStampCorder().decode(data: messageData),
+              let timeStamp = timeStamps.first else { return }
+        Task {
+            await MainActor.run {
+                self.edit(timeStamp: timeStamp)
+            }
         }
     }
 }

--- a/TimeStampApp/TimeStampListViewModel.swift
+++ b/TimeStampApp/TimeStampListViewModel.swift
@@ -8,9 +8,10 @@
 import Foundation
 import SwiftUI
 import Combine
+import WatchConnectivity
 
 @MainActor
-final class TimeStampListViewModel: ObservableObject {
+final class TimeStampListViewModel: NSObject, ObservableObject {
     @Published var timeStamps: [TimeStamp] = []
     private let repository: UserDefaultTimeStampRepository
     
@@ -18,6 +19,8 @@ final class TimeStampListViewModel: ObservableObject {
     
     init(repository: UserDefaultTimeStampRepository) {
         self.repository = repository
+        
+        super.init()
         
         self.repository.timeStamps
             .sink { timeStamps in
@@ -79,5 +82,16 @@ extension TimeStampListViewModel {
                 }
             }
         )
+    }
+}
+
+extension TimeStampListViewModel: WCSessionDelegate {
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+    }
+    
+    func sessionDidBecomeInactive(_ session: WCSession) {
+    }
+    
+    func sessionDidDeactivate(_ session: WCSession) {
     }
 }


### PR DESCRIPTION
## 概要
- WatchConnectivityを利用
- Watch上でボタンを押されたら、[TimeStamp]をjsonにエンコードしてiOS側に送る
- iOS側でデコードしてUserDefaultTimeStampRepositoryでタイムスタンプを保存する

## 作業内容

1b60a21 fix: WatchConnectivityを使うのでrepositoryを削除
670207b update: ContentViewからAddTimeStampViewを呼び出す
531a938 update: conditional compilation blockを使ってOS毎に呼び出すContentViewを変える
3dcd29a update: WCSessionDelegateに準拠
7e7c63b update: WCSessionDelegateに準拠
1443b0f update: Watchから送ったタイムスタンプをiPhone側で受け取ってタイムスタンプを追加する
1e4564b fix: guardを使ってネストを少なくする
6aefb27 fix: タイムスタンプの保存をメインスレッドで行うように修正
