### PR TITLE
選択したタイムスタンプの分数差を表示する機能を追加

### DIFF
--- a/TimeStampApp/Model/TimeStamp.swift
+++ b/TimeStampApp/Model/TimeStamp.swift
@@ -11,6 +11,7 @@ import Foundation
     let id: UUID
     let date: Date
     var type: DateType? = nil
+    var isSelected = false
     
     init(id: UUID, date: Date, type: DateType? = nil) {
         self.id = id

--- a/TimeStampMac/TimeStampList.swift
+++ b/TimeStampMac/TimeStampList.swift
@@ -10,15 +10,30 @@ import SFUserFriendlySymbols
 
 struct TimeStampList: View {
     @ObservedObject var viewModel: TimeStampListViewModel
-
+    
+    @State private var showTimeStampDuration = false
+    
+    private var timeStampDuration: String {
+        guard let duration = viewModel.duration?.description else { return "" }
+        return duration + "min"
+    }
+    
     var body: some View {
         VStack {
             HStack(spacing: 32) {
                 addTimeStampButton
+                calculateTimeStampDurationButton
                 deleteAllButton
             }
             .padding()
             list
+                .alert(timeStampDuration, isPresented: $showTimeStampDuration) {
+                    Button {
+                        showTimeStampDuration = false
+                    } label: {
+                        Text("OK")
+                    }
+                }
         }
     }
     
@@ -27,6 +42,16 @@ struct TimeStampList: View {
             viewModel.runAction(.edit(timeStamp: .currentTimeStamp))
         } label: {
             Image(symbol: .plus)
+        }
+        .buttonStyle(.bordered)
+    }
+    
+    var calculateTimeStampDurationButton: some View {
+        Button {
+            viewModel.runAction(.calculateTimeStampDuration)
+            showTimeStampDuration = true
+        } label: {
+            Image(symbol: .clock)
         }
         .buttonStyle(.bordered)
     }
@@ -43,7 +68,24 @@ struct TimeStampList: View {
     var list: some View {
         List {
             ForEach(viewModel.timeStamps) { timeStamp in
+                cell(timeStamp: timeStamp)
+            }
+        }
+    }
+    
+    func cell(timeStamp: TimeStamp) -> some View {
+        HStack {
+            Button {
+                viewModel.runAction(.selectTimeStamp(timeStamp: timeStamp))
+            } label: {
                 Text(timeStamp.date.yyyyMMDDEEEHHmm)
+            }
+            .buttonStyle(.plain)
+            
+            Spacer()
+            
+            if timeStamp.isSelected {
+                Image(symbol: .checkmark)
             }
         }
     }

--- a/TimeStampMac/TimeStampListViewModel.swift
+++ b/TimeStampMac/TimeStampListViewModel.swift
@@ -11,6 +11,7 @@ import Combine
 @MainActor
 final class TimeStampListViewModel: ObservableObject {
     @Published var timeStamps: [TimeStamp] = []
+    @Published var duration: Int? = nil
     private let repository: UserDefaultTimeStampRepository
     private var cancellables: Set<AnyCancellable> = .init()
     
@@ -26,6 +27,8 @@ final class TimeStampListViewModel: ObservableObject {
     
     enum Action {
         case edit(timeStamp: TimeStamp)
+        case calculateTimeStampDuration
+        case selectTimeStamp(timeStamp: TimeStamp)
         case deleteAll
     }
     
@@ -33,6 +36,10 @@ final class TimeStampListViewModel: ObservableObject {
         switch action {
         case .edit(let timeStamp):
             edit(timeStamp: timeStamp)
+        case .calculateTimeStampDuration:
+            self.duration = calculateTimeStampDuration()
+        case .selectTimeStamp(let timeStamp):
+            selectTimeStamp(timeStamp: timeStamp)
         case .deleteAll:
             deleteAll()
         }
@@ -40,6 +47,20 @@ final class TimeStampListViewModel: ObservableObject {
     
     private func edit(timeStamp: TimeStamp) {
         repository.edit(timeStamp: timeStamp)
+    }
+    
+    private func calculateTimeStampDuration() -> Int? {
+        let selectedTimeStampDates = timeStamps
+            .filter(\.isSelected)
+            .map(\.date)
+        guard let minDate = selectedTimeStampDates.min(), let maxDate = selectedTimeStampDates.max() else { return nil }
+        return Int(maxDate.timeIntervalSince(minDate)) / 60
+    }
+    
+    private func selectTimeStamp(timeStamp: TimeStamp) {
+        var timeStamp = timeStamp
+        timeStamp.isSelected.toggle()
+        edit(timeStamp: timeStamp)
     }
     
     private func deleteAll() {


### PR DESCRIPTION
## 概要
- MacOSアプリにてタイムスタンプをタップ時にチェックアイコンを表示する
- 選択されたものを配列に入れて、一番若いものと古いものを取得して分数の差分を取得
- 取得した差分をアラートとして画面に表示する

## 作業内容
- 3dce182 feature: タイムスタンプに選択状態かどうかのプロパティを追加
- 018049b feature: 選択されたタイムスタンプの配列から一番若いものと古いものを取得して分数の差分を表示する機能を追加
