### PR TITLE
同じレイアウトのパーツをViewPartsに切り出す

### DIFF
--- a/TimeStamp Watch App/AddTimeStampView.swift
+++ b/TimeStamp Watch App/AddTimeStampView.swift
@@ -14,6 +14,7 @@ struct AddTimeStampView: View {
         AddTimeStampButton {
             viewModel.runAction(.edit(timeStamp: .currentTimeStamp))
         }
+        .buttonStyle(.plain)
     }
 }
 

--- a/TimeStampApp.xcodeproj/project.pbxproj
+++ b/TimeStampApp.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		6D4687D42BBF063D00F4A9FB /* AddTimeStampViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4687D32BBF063D00F4A9FB /* AddTimeStampViewModel.swift */; };
 		6D70CC242BE8C692006CD697 /* TrashTimeStampButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D70CC232BE8C692006CD697 /* TrashTimeStampButton.swift */; };
 		6D70CC252BE8C692006CD697 /* TrashTimeStampButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D70CC232BE8C692006CD697 /* TrashTimeStampButton.swift */; };
+		6D70CC272BE8C7E7006CD697 /* EditTimeStampButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D70CC262BE8C7E7006CD697 /* EditTimeStampButton.swift */; };
 		6D824F562BC92F200054B1D1 /* TimeStampCorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D824F552BC92F200054B1D1 /* TimeStampCorder.swift */; };
 		6D824F572BC92F200054B1D1 /* TimeStampCorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D824F552BC92F200054B1D1 /* TimeStampCorder.swift */; };
 		6D824F582BC92F200054B1D1 /* TimeStampCorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D824F552BC92F200054B1D1 /* TimeStampCorder.swift */; };
@@ -145,6 +146,7 @@
 		6D4687CC2BBF042D00F4A9FB /* AddTimeStampView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTimeStampView.swift; sourceTree = "<group>"; };
 		6D4687D32BBF063D00F4A9FB /* AddTimeStampViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTimeStampViewModel.swift; sourceTree = "<group>"; };
 		6D70CC232BE8C692006CD697 /* TrashTimeStampButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashTimeStampButton.swift; sourceTree = "<group>"; };
+		6D70CC262BE8C7E7006CD697 /* EditTimeStampButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTimeStampButton.swift; sourceTree = "<group>"; };
 		6D824F552BC92F200054B1D1 /* TimeStampCorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeStampCorder.swift; sourceTree = "<group>"; };
 		6D824F5A2BC92FE80054B1D1 /* UserDefaultTimeStampRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultTimeStampRepository.swift; sourceTree = "<group>"; };
 		6D824F612BC94F4A0054B1D1 /* InMemoryTimeStampRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryTimeStampRepository.swift; sourceTree = "<group>"; };
@@ -284,6 +286,7 @@
 			children = (
 				6D4687C82BBF037000F4A9FB /* AddTimeStampButton.swift */,
 				6D70CC232BE8C692006CD697 /* TrashTimeStampButton.swift */,
+				6D70CC262BE8C7E7006CD697 /* EditTimeStampButton.swift */,
 			);
 			path = ViewParts;
 			sourceTree = "<group>";
@@ -616,6 +619,7 @@
 				6D46878F2BBEFB3200F4A9FB /* TimeStamp.swift in Sources */,
 				6DD6E07F2B484B6E00351D0B /* ContentView.swift in Sources */,
 				6D824F5B2BC92FE80054B1D1 /* UserDefaultTimeStampRepository.swift in Sources */,
+				6D70CC272BE8C7E7006CD697 /* EditTimeStampButton.swift in Sources */,
 				6DD6E07D2B484B6E00351D0B /* TimeStampApp.swift in Sources */,
 				6D4687C92BBF037000F4A9FB /* AddTimeStampButton.swift in Sources */,
 				6DD6E08D2B484E3100351D0B /* TimeStampListViewModel.swift in Sources */,

--- a/TimeStampApp.xcodeproj/project.pbxproj
+++ b/TimeStampApp.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		6D4687D02BBF051B00F4A9FB /* TimeStampRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4687932BBEFB6200F4A9FB /* TimeStampRepository.swift */; };
 		6D4687D22BBF053E00F4A9FB /* SFUserFriendlySymbols in Frameworks */ = {isa = PBXBuildFile; productRef = 6D4687D12BBF053E00F4A9FB /* SFUserFriendlySymbols */; };
 		6D4687D42BBF063D00F4A9FB /* AddTimeStampViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4687D32BBF063D00F4A9FB /* AddTimeStampViewModel.swift */; };
+		6D70CC242BE8C692006CD697 /* TrashTimeStampButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D70CC232BE8C692006CD697 /* TrashTimeStampButton.swift */; };
+		6D70CC252BE8C692006CD697 /* TrashTimeStampButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D70CC232BE8C692006CD697 /* TrashTimeStampButton.swift */; };
 		6D824F562BC92F200054B1D1 /* TimeStampCorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D824F552BC92F200054B1D1 /* TimeStampCorder.swift */; };
 		6D824F572BC92F200054B1D1 /* TimeStampCorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D824F552BC92F200054B1D1 /* TimeStampCorder.swift */; };
 		6D824F582BC92F200054B1D1 /* TimeStampCorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D824F552BC92F200054B1D1 /* TimeStampCorder.swift */; };
@@ -142,6 +144,7 @@
 		6D4687C82BBF037000F4A9FB /* AddTimeStampButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTimeStampButton.swift; sourceTree = "<group>"; };
 		6D4687CC2BBF042D00F4A9FB /* AddTimeStampView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTimeStampView.swift; sourceTree = "<group>"; };
 		6D4687D32BBF063D00F4A9FB /* AddTimeStampViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTimeStampViewModel.swift; sourceTree = "<group>"; };
+		6D70CC232BE8C692006CD697 /* TrashTimeStampButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashTimeStampButton.swift; sourceTree = "<group>"; };
 		6D824F552BC92F200054B1D1 /* TimeStampCorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeStampCorder.swift; sourceTree = "<group>"; };
 		6D824F5A2BC92FE80054B1D1 /* UserDefaultTimeStampRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultTimeStampRepository.swift; sourceTree = "<group>"; };
 		6D824F612BC94F4A0054B1D1 /* InMemoryTimeStampRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryTimeStampRepository.swift; sourceTree = "<group>"; };
@@ -280,6 +283,7 @@
 			isa = PBXGroup;
 			children = (
 				6D4687C82BBF037000F4A9FB /* AddTimeStampButton.swift */,
+				6D70CC232BE8C692006CD697 /* TrashTimeStampButton.swift */,
 			);
 			path = ViewParts;
 			sourceTree = "<group>";
@@ -568,6 +572,7 @@
 				6D824F922BC9661A0054B1D1 /* AddTimeStampButton.swift in Sources */,
 				6D40F7662B6BDC6600D03D23 /* TimeStampList.swift in Sources */,
 				6D4687912BBEFB3200F4A9FB /* TimeStamp.swift in Sources */,
+				6D70CC252BE8C692006CD697 /* TrashTimeStampButton.swift in Sources */,
 				6D824F5D2BC92FE80054B1D1 /* UserDefaultTimeStampRepository.swift in Sources */,
 				6D824F8A2BC964D30054B1D1 /* AddTimeStampView.swift in Sources */,
 				6D40F75B2B6BDC1500D03D23 /* ContentView.swift in Sources */,
@@ -604,6 +609,7 @@
 				6D46878D2BBEFB1D00F4A9FB /* Date+Extension.swift in Sources */,
 				6DD6E08B2B484DF900351D0B /* TimeStampList.swift in Sources */,
 				6D824F912BC9659F0054B1D1 /* AddTimeStampView.swift in Sources */,
+				6D70CC242BE8C692006CD697 /* TrashTimeStampButton.swift in Sources */,
 				6D824F562BC92F200054B1D1 /* TimeStampCorder.swift in Sources */,
 				6D4687942BBEFB6200F4A9FB /* TimeStampRepository.swift in Sources */,
 				6D824F622BC94F4A0054B1D1 /* InMemoryTimeStampRepository.swift in Sources */,

--- a/TimeStampApp.xcodeproj/project.pbxproj
+++ b/TimeStampApp.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		6D70CC242BE8C692006CD697 /* TrashTimeStampButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D70CC232BE8C692006CD697 /* TrashTimeStampButton.swift */; };
 		6D70CC252BE8C692006CD697 /* TrashTimeStampButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D70CC232BE8C692006CD697 /* TrashTimeStampButton.swift */; };
 		6D70CC272BE8C7E7006CD697 /* EditTimeStampButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D70CC262BE8C7E7006CD697 /* EditTimeStampButton.swift */; };
+		6D70CC292BE8CFAB006CD697 /* DeleteTimeStampButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D70CC282BE8CFAB006CD697 /* DeleteTimeStampButton.swift */; };
 		6D824F562BC92F200054B1D1 /* TimeStampCorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D824F552BC92F200054B1D1 /* TimeStampCorder.swift */; };
 		6D824F572BC92F200054B1D1 /* TimeStampCorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D824F552BC92F200054B1D1 /* TimeStampCorder.swift */; };
 		6D824F582BC92F200054B1D1 /* TimeStampCorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D824F552BC92F200054B1D1 /* TimeStampCorder.swift */; };
@@ -147,6 +148,7 @@
 		6D4687D32BBF063D00F4A9FB /* AddTimeStampViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTimeStampViewModel.swift; sourceTree = "<group>"; };
 		6D70CC232BE8C692006CD697 /* TrashTimeStampButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashTimeStampButton.swift; sourceTree = "<group>"; };
 		6D70CC262BE8C7E7006CD697 /* EditTimeStampButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTimeStampButton.swift; sourceTree = "<group>"; };
+		6D70CC282BE8CFAB006CD697 /* DeleteTimeStampButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteTimeStampButton.swift; sourceTree = "<group>"; };
 		6D824F552BC92F200054B1D1 /* TimeStampCorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeStampCorder.swift; sourceTree = "<group>"; };
 		6D824F5A2BC92FE80054B1D1 /* UserDefaultTimeStampRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultTimeStampRepository.swift; sourceTree = "<group>"; };
 		6D824F612BC94F4A0054B1D1 /* InMemoryTimeStampRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryTimeStampRepository.swift; sourceTree = "<group>"; };
@@ -287,6 +289,7 @@
 				6D4687C82BBF037000F4A9FB /* AddTimeStampButton.swift */,
 				6D70CC232BE8C692006CD697 /* TrashTimeStampButton.swift */,
 				6D70CC262BE8C7E7006CD697 /* EditTimeStampButton.swift */,
+				6D70CC282BE8CFAB006CD697 /* DeleteTimeStampButton.swift */,
 			);
 			path = ViewParts;
 			sourceTree = "<group>";
@@ -618,6 +621,7 @@
 				6D824F622BC94F4A0054B1D1 /* InMemoryTimeStampRepository.swift in Sources */,
 				6D46878F2BBEFB3200F4A9FB /* TimeStamp.swift in Sources */,
 				6DD6E07F2B484B6E00351D0B /* ContentView.swift in Sources */,
+				6D70CC292BE8CFAB006CD697 /* DeleteTimeStampButton.swift in Sources */,
 				6D824F5B2BC92FE80054B1D1 /* UserDefaultTimeStampRepository.swift in Sources */,
 				6D70CC272BE8C7E7006CD697 /* EditTimeStampButton.swift in Sources */,
 				6DD6E07D2B484B6E00351D0B /* TimeStampApp.swift in Sources */,

--- a/TimeStampApp/TimeStampList.swift
+++ b/TimeStampApp/TimeStampList.swift
@@ -29,7 +29,9 @@ struct TimeStampList: View {
                         }
                     }
                     .confirmationDialog("すべて削除しますか？", isPresented: $isDeletedAll) {
-                       deleteAllButton
+                        DeleteTimeStampButton {
+                            viewModel.runAction(.deleteAll)
+                        }
                     }
             }
         }
@@ -60,14 +62,6 @@ struct TimeStampList: View {
             }
         }
         .environment(\.editMode, self.$editMode)
-    }
-    
-    var deleteAllButton: some View {
-        Button(role: .destructive) {
-            viewModel.runAction(.deleteAll)
-        } label: {
-            Text("すべて削除")
-        }
     }
     
     func cell(timeStamp: TimeStamp) -> some View {

--- a/TimeStampApp/TimeStampList.swift
+++ b/TimeStampApp/TimeStampList.swift
@@ -20,7 +20,9 @@ struct TimeStampList: View {
                     .navigationTitle("Time Stamp List")
                     .toolbar {
                         ToolbarItem(placement: .topBarLeading) {
-                            trashButton
+                            TrashTimeStampButton {
+                                isDeletedAll.toggle()
+                            }
                         }
                         ToolbarItem(placement: .topBarTrailing) {
                             editButton
@@ -63,14 +65,6 @@ struct TimeStampList: View {
         } label: {
             Text(editMode.isEditing ? "Done" : "Edit")
                 .bold()
-        }
-    }
-    
-    var trashButton: some View {
-        Button {
-            isDeletedAll.toggle()
-        } label: {
-            Image(symbol: .trash)
         }
     }
     

--- a/TimeStampApp/TimeStampList.swift
+++ b/TimeStampApp/TimeStampList.swift
@@ -25,7 +25,7 @@ struct TimeStampList: View {
                             }
                         }
                         ToolbarItem(placement: .topBarTrailing) {
-                            editButton
+                            EditTimeStampButton(editMode: self.$editMode)
                         }
                     }
                     .confirmationDialog("すべて削除しますか？", isPresented: $isDeletedAll) {
@@ -60,15 +60,6 @@ struct TimeStampList: View {
             }
         }
         .environment(\.editMode, self.$editMode)
-    }
-    
-    var editButton: some View {
-        Button {
-            editMode = editMode.isEditing ? .inactive : .active
-        } label: {
-            Text(editMode.isEditing ? "Done" : "Edit")
-                .bold()
-        }
     }
     
     var deleteAllButton: some View {

--- a/TimeStampApp/TimeStampList.swift
+++ b/TimeStampApp/TimeStampList.swift
@@ -35,7 +35,10 @@ struct TimeStampList: View {
         }
         .listStyle(.insetGrouped)
         .overlay(alignment: .bottomTrailing) {
-            addTimeStampButton
+            AddTimeStampButton {
+                viewModel.runAction(.edit(timeStamp: .currentTimeStamp))
+            }
+            .padding()
         }
         .onOpenURL { url in
             if url == URL(string: "com-time-stamp-app://") {
@@ -93,20 +96,5 @@ struct TimeStampList: View {
         } label: {
             Text("削除")
         }
-    }
-    
-    var addTimeStampButton: some View {
-        Button {
-            viewModel.runAction(.edit(timeStamp: .currentTimeStamp))
-        } label: {
-            Image(symbol: .plus)
-                .resizable()
-                .frame(width: 44, height: 44)
-                .foregroundStyle(.white)
-                .padding()
-                .background(Color.blue)
-                .clipShape(Circle())
-        }
-        .padding()
     }
 }

--- a/TimeStampApp/ViewParts/AddTimeStampButton.swift
+++ b/TimeStampApp/ViewParts/AddTimeStampButton.swift
@@ -11,6 +11,14 @@ import SFUserFriendlySymbols
 struct AddTimeStampButton: View {
     var action: () -> Void
     var body: some View {
+        #if os(macOS)
+        Button {
+            action()
+        } label: {
+            Image(symbol: .plus)
+        }
+        .buttonStyle(.bordered)
+        #else
         Button {
             action()
         } label: {
@@ -22,6 +30,7 @@ struct AddTimeStampButton: View {
                 .background(Color.blue)
                 .clipShape(Circle())
         }
+        #endif
     }
 }
 

--- a/TimeStampApp/ViewParts/DeleteTimeStampButton.swift
+++ b/TimeStampApp/ViewParts/DeleteTimeStampButton.swift
@@ -1,0 +1,25 @@
+//
+//  DeleteTimeStampButton.swift
+//  TimeStampApp
+//
+//  Created by Iori Suzuki on 2024/05/06.
+//
+
+import SwiftUI
+
+struct DeleteTimeStampButton: View {
+    var action: () -> Void
+    var body: some View {
+        Button(role: .destructive) {
+            action()
+        } label: {
+            Text("すべて削除")
+        }
+    }
+}
+
+#Preview {
+    DeleteTimeStampButton {
+        
+    }
+}

--- a/TimeStampApp/ViewParts/EditTimeStampButton.swift
+++ b/TimeStampApp/ViewParts/EditTimeStampButton.swift
@@ -1,0 +1,25 @@
+//
+//  EditTimeStampButton.swift
+//  TimeStampApp
+//
+//  Created by Iori Suzuki on 2024/05/06.
+//
+
+import SwiftUI
+
+struct EditTimeStampButton: View {
+    @Binding var editMode: EditMode
+    
+    var body: some View {
+        Button {
+            editMode = editMode.isEditing ? .inactive : .active
+        } label: {
+            Text(editMode.isEditing ? "Done" : "Edit")
+                .bold()
+        }
+    }
+}
+
+#Preview {
+    EditTimeStampButton(editMode: .constant(.inactive))
+}

--- a/TimeStampApp/ViewParts/TrashTimeStampButton.swift
+++ b/TimeStampApp/ViewParts/TrashTimeStampButton.swift
@@ -1,0 +1,25 @@
+//
+//  TrashTimeStampButton.swift
+//  TimeStampApp
+//
+//  Created by Iori Suzuki on 2024/05/06.
+//
+
+import SwiftUI
+
+struct TrashTimeStampButton: View {
+    var action: () -> Void
+    var body: some View {
+        Button {
+            action()
+        } label: {
+            Image(symbol: .trash)
+        }
+    }
+}
+
+#Preview {
+    TrashTimeStampButton {
+        
+    }
+}

--- a/TimeStampMac/TimeStampList.swift
+++ b/TimeStampMac/TimeStampList.swift
@@ -25,7 +25,9 @@ struct TimeStampList: View {
                     viewModel.runAction(.edit(timeStamp: .currentTimeStamp))
                 }
                 calculateTimeStampDurationButton
-                deleteAllButton
+                TrashTimeStampButton {
+                    viewModel.runAction(.deleteAll)
+                }
             }
             .padding()
             list
@@ -45,15 +47,6 @@ struct TimeStampList: View {
             showTimeStampDuration = true
         } label: {
             Image(symbol: .clock)
-        }
-        .buttonStyle(.bordered)
-    }
-    
-    var deleteAllButton: some View {
-        Button {
-            viewModel.runAction(.deleteAll)
-        } label: {
-            Image(symbol: .trash)
         }
         .buttonStyle(.bordered)
     }

--- a/TimeStampMac/TimeStampList.swift
+++ b/TimeStampMac/TimeStampList.swift
@@ -55,18 +55,16 @@ struct TimeStampList: View {
         List {
             ForEach(viewModel.timeStamps) { timeStamp in
                 cell(timeStamp: timeStamp)
+                    .onTapGesture {
+                        viewModel.runAction(.selectTimeStamp(timeStamp: timeStamp))
+                    }
             }
         }
     }
     
     func cell(timeStamp: TimeStamp) -> some View {
         HStack {
-            Button {
-                viewModel.runAction(.selectTimeStamp(timeStamp: timeStamp))
-            } label: {
-                Text(timeStamp.date.yyyyMMDDEEEHHmm)
-            }
-            .buttonStyle(.plain)
+            Text(timeStamp.date.yyyyMMDDEEEHHmm)
             
             Spacer()
             

--- a/TimeStampMac/TimeStampList.swift
+++ b/TimeStampMac/TimeStampList.swift
@@ -21,7 +21,9 @@ struct TimeStampList: View {
     var body: some View {
         VStack {
             HStack(spacing: 32) {
-                addTimeStampButton
+                AddTimeStampButton {
+                    viewModel.runAction(.edit(timeStamp: .currentTimeStamp))
+                }
                 calculateTimeStampDurationButton
                 deleteAllButton
             }
@@ -35,15 +37,6 @@ struct TimeStampList: View {
                     }
                 }
         }
-    }
-    
-    var addTimeStampButton: some View {
-        Button {
-            viewModel.runAction(.edit(timeStamp: .currentTimeStamp))
-        } label: {
-            Image(symbol: .plus)
-        }
-        .buttonStyle(.bordered)
     }
     
     var calculateTimeStampDurationButton: some View {

--- a/TimeStampWidget/TimeStampWidget.swift
+++ b/TimeStampWidget/TimeStampWidget.swift
@@ -51,15 +51,10 @@ struct TimeStampWidgetEntryView : View {
 
 struct TimeStampWidgetView: View {
     var body: some View {
-        Image(symbol: .plus)
-            .resizable()
-            .scaledToFit()
-            .padding()
-            .foregroundStyle(.white)
-            .padding()
-            .background(Color.blue)
-            .clipShape(Circle())
-            .widgetURL(URL(string: "com-time-stamp-app://"))
+        AddTimeStampButton {
+        }
+        .buttonStyle(.plain)
+        .widgetURL(URL(string: "com-time-stamp-app://"))
     }
 }
 


### PR DESCRIPTION
## 作業内容

d9f554f feature: ゴミ箱ボタンをプロパティから共通パーツ化
fd0b685 fix: プロパティから共通パーツのAddTimeStampButtonを使うように修正
fbc95f0 feature: 編集ボタンを共通パーツ化
df4f4a5 feature: すべて削除ボタンを共通パーツ化
f37bc62 fix: 共通パーツのAddTimeStampButtonを使うように修正
b458431 feature: macOSの場合はAddTimeStampButtonのUIを変える
b5ed2ed fix: 共通パーツのTrashTimeStampButtonを使うように修正
86225e7 fix: ボタンではなくcellのonTapGestureでタップされたかを判定するように修正
6a80894 fix: 共通パーツのAddTimeStampButtonを使うように修正
31af55c fix: 2重にボタンが表示されるのでbuttonStyleをplainに修正
